### PR TITLE
ci: allow golang.org/x PATENTS license in dependency review

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -7,3 +7,6 @@ allow_licenses:
   - 'BSD-2-Clause'
   - 'BSD-3-Clause'
   - 'Apache-2.0'
+  # golang.org/x/* modules ship a PATENTS file that scancode reports as an
+  # extra LicenseRef alongside BSD-3-Clause; allow it so x/* bumps don't fail.
+  - 'LicenseRef-scancode-google-patent-license-golang'


### PR DESCRIPTION
## Problem

`dependency-review` fails on every `golang.org/x/*` bump (e.g. #43, #43's `x/sync@0.20.0`):

```
The following dependencies have incompatible licenses:
go.mod » golang.org/x/sync@0.20.0 – License: BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang
##[error]Dependency review detected incompatible licenses.
```

The Go team's `PATENTS` file is detected by scancode as an extra `LicenseRef`. Because the config uses `allow_licenses` (allow-list), the SPDX `... AND LicenseRef-...` expression fails — every component must be allowed, and the patent ref wasn't.

## Fix

Add `LicenseRef-scancode-google-patent-license-golang` to `allow_licenses`. This is the standard Go patent grant that accompanies BSD-3-Clause on all `golang.org/x/*` code, which is already allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)